### PR TITLE
add default variables for split_full_name

### DIFF
--- a/parser.php
+++ b/parser.php
@@ -12,6 +12,8 @@ class FullNameParser
 
   public function split_full_name($full_name) {
       $full_name = trim($full_name);
+      // setup default values
+      extract( array( 'salutation' => '','fname' => '', 'initials' => '', 'lname' => '', 'suffix' => '' ));
       // split into words
       $unfiltered_name_parts = explode(" ",$full_name);
       // completely ignore any words in parentheses


### PR DESCRIPTION
In local testing there are cases where all the pieces are not supplied and calling the undefined variables to populate `$name` results in fatal errors. This defines the vars at the beginning of the method to provide default empty values.
