### PR TITLE
multi-word nicknames and normalized professional suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Check examples.php for the test suite and examples of how various name formats a
 
 * Handle the "Lname, Fname" format
 * Separate the parsing of the name from the normalization & capitalization & make those optional.
-* Handle any number of words in parenthesis (currently only handles a single word)
-* Normalize the formatting of suffixes (PHD -> PhD)
 * Add rule to capitalize two letter names w/ no vowels (ex. "JP" but not "Jo")
 * Add common name libraries to allow for things like gender detection
 


### PR DESCRIPTION
* professional suffix now gets normalized if it's found in the dictionary

* nickname parsing now allows for multi-word nicknames

* removed single quote nickname markers to prevent clashes with names containing apostrophes (primarily Arabic transliterations)

* added an additional compound identifier (der)

* some people write their suffix in numeric form, dictionary now allows for this