### PR TITLE
Multibytes string

### DIFF
--- a/parser.php
+++ b/parser.php
@@ -157,9 +157,9 @@ class FullNameParser {
     $professional_suffix = $this->get_pro_suffix($full_name);
 
     // The position of the first professional suffix denotes the end of the name and the start of suffixes
-    $first_suffix_index = strlen($full_name);
+    $first_suffix_index = mb_strlen($full_name);
     foreach ($professional_suffix as $key => $psx) {
-      $start = strpos($full_name, $psx);
+      $start = mb_strpos($full_name, $psx);
       if( $start === FALSE ) {
         echo "ASSERT ERROR, the professional suffix:".$psx." cannot be found in the full name:".$full_name."<br>";
         continue;
@@ -170,16 +170,16 @@ class FullNameParser {
     }
 
     // everything to the right of the first professional suffix is part of the suffix
-    $suffix = substr($full_name, $first_suffix_index);
+    $suffix = mb_substr($full_name, $first_suffix_index);
 
     // remove the suffixes from the full_name
-    $full_name = substr($full_name, 0, $first_suffix_index);
+    $full_name = mb_substr($full_name, 0, $first_suffix_index);
 
     # Deal with nickname, push to array
     $has_nick = $this->get_nickname($full_name);
     if ($has_nick) {
       # Remove wrapper chars from around nickname
-      $name['nickname'] = substr($has_nick, 1, (strlen($has_nick) - 2));
+      $name['nickname'] = mb_substr($has_nick, 1, (mb_strlen($has_nick) - 2));
       # Remove the nickname from the full name
       $full_name = str_replace($has_nick, '', $full_name);
       # Get rid of consecutive spaces left by the removal
@@ -218,13 +218,13 @@ class FullNameParser {
     foreach ($unfiltered_name_parts as $key => $name_part) {
       $name_part = trim($name_part);
       $name_part = rtrim($name_part,',');
-      if(strlen($name_part) == '1') {
+      if(mb_strlen($name_part) == '1') {
         // If any word left is of one character that is not alphabetic then it is not a real word, so remove it
-        if( ! ctype_alpha($name_part)) {
+        if( ! $this->mb_ctype_alpha($name_part)) {
           $name_part = "";
         }
       }
-      if( strlen(trim($name_part)) ) {
+      if(mb_strlen(trim($name_part)) ) {
         $name_arr[] = $name_part;
       }
     }
@@ -250,15 +250,15 @@ class FullNameParser {
           # for ex: "R. Jason Smith" => "Jason Smith" & "R." is stored as an initial
           # but "R. J. Smith" => "R. Smith" and "J." is stored as an initial
           if ($this->is_initial($unfiltered_name_parts[$i+1])) {
-            $fname .= " ".strtoupper($word);
+            $fname .= " ".mb_strtoupper($word);
           }
           else {
-            $initials .= " ".strtoupper($word);
+            $initials .= " ".mb_strtoupper($word);
           }
         }
         # otherwise, just go ahead and save the initial
         else {
-          $initials .= " ".strtoupper($word);
+          $initials .= " ".mb_strtoupper($word);
         }
       }
       else {
@@ -348,7 +348,7 @@ class FullNameParser {
    */
   protected function get_nickname($name) {
     if (preg_match("/[\(|\"].*?[\)|\"]/", $name, $matches)) {
-      if( ! in_array( strtolower($matches[0]), $this->not_nicknames ) ) {
+      if( ! in_array( mb_strtolower($matches[0]), $this->not_nicknames ) ) {
         return $matches[0];
       } else {
         return false;
@@ -369,11 +369,11 @@ class FullNameParser {
   protected function is_line_suffix($word, $name) {
 
     # Ignore periods and righ commas, normalize case
-    $word = str_replace('.', '', strtolower($word));
+    $word = str_replace('.', '', mb_strtolower($word));
     $word = rtrim($word,',');
 
     # Search the array for our word
-    $line_match = array_search($word, array_map('strtolower', $this->dict['suffixes']['line']));
+    $line_match = array_search($word, array_map('mb_strtolower', $this->dict['suffixes']['line']));
 
     # Now test our edge cases based on lineage
     if ($line_match !== false) {
@@ -389,7 +389,7 @@ class FullNameParser {
 
         # If name is Joshua Senior, it's pretty likely that Senior is the surname
         # However, if the name is Joshua Jones Senior, then it's likely a suffix
-        if (str_word_count($name) < 3) {
+        if ($this->mb_str_word_count($name) < 3) {
           return false;
         }
 
@@ -415,7 +415,7 @@ class FullNameParser {
    * @return boolean
    */
   protected function is_salutation($word) {
-    $word = str_replace('.', '', strtolower($word));
+    $word = str_replace('.', '', mb_strtolower($word));
     foreach ($this->dict['prefix'] as $replace => $originals) {
       if (in_array($word, $originals)) {
         return $replace;
@@ -433,7 +433,7 @@ class FullNameParser {
    * @return boolean
    */
   protected function is_compound($word) {
-    return array_search(strtolower($word), $this->dict['compound']);
+    return array_search(mb_strtolower($word), $this->dict['compound']);
   }
 
 
@@ -445,7 +445,7 @@ class FullNameParser {
    * @return boolean
    */
   protected function is_initial($word) {
-    return ((strlen($word) == 1) || (strlen($word) == 2 && $word{1} == "."));
+    return ((mb_strlen($word) == 1) || (mb_strlen($word) == 2 && $word{1} == "."));
   }
 
 
@@ -457,7 +457,7 @@ class FullNameParser {
    * @return boolean
    */
   protected function is_camel_case($word) {
-    if (preg_match("/[A-Za-z]([A-Z]*[a-z][a-z]*[A-Z]|[a-z]*[A-Z][A-Z]*[a-z])[A-Za-z]*/", $word)) {
+    if (preg_match('/\p{L}(\p{Lu}*\p{Ll}\p{Ll}*\p{Lu}|\p{Ll}*\p{Lu}\p{Lu}*\p{Ll})\p{L}*/', $word)) {
       return true;
     }
     return false;
@@ -468,43 +468,43 @@ class FullNameParser {
   public function fix_case($word) {
 
     # Fix case for words split by periods (J.P.)
-    if (strpos($word, '.') !== false) {
+    if (mb_strpos($word, '.') !== false) {
       $word = $this->safe_ucfirst(".", $word);;
     }
 
     # Fix case for words split by hyphens (Kimura-Fay)
-    if (strpos($word, '-') !== false) {
+    if (mb_strpos($word, '-') !== false) {
       $word = $this->safe_ucfirst("-", $word);
     }
 
     # Special case for single letters
-    if (strlen($word) == 1) {
-      $word = strtoupper($word);
+    if (mb_strlen($word) == 1) {
+      $word = mb_strtoupper($word);
     }
 
     # Special case for 2-letter words
-    if (strlen($word) == 2) {
+    if (mb_strlen($word) == 2) {
       # Both letters vowels (uppercase both)
-      if (in_array(strtolower($word{0}), $this->dict['vowels']) && in_array(strtolower($word{1}), $this->dict['vowels'])) {
-        $word = strtoupper($word);
+      if (in_array(mb_strtolower($word{0}), $this->dict['vowels']) && in_array(mb_strtolower($word{1}), $this->dict['vowels'])) {
+        $word = mb_strtoupper($word);
       }
       # Both letters consonants (uppercase both)
-      if (!in_array(strtolower($word{0}), $this->dict['vowels']) && !in_array(strtolower($word{1}), $this->dict['vowels'])) {
-        $word = strtoupper($word);
+      if (!in_array(mb_strtolower($word{0}), $this->dict['vowels']) && !in_array(mb_strtolower($word{1}), $this->dict['vowels'])) {
+        $word = mb_strtoupper($word);
       }
       # First letter is vowel, second letter consonant (uppercase first)
-      if (in_array(strtolower($word{0}), $this->dict['vowels']) && !in_array(strtolower($word{1}), $this->dict['vowels'])) {
-        $word = ucfirst(strtolower($word));
+      if (in_array(mb_strtolower($word{0}), $this->dict['vowels']) && !in_array(mb_strtolower($word{1}), $this->dict['vowels'])) {
+        $word = ucfirst(mb_strtolower($word));
       }
       # First letter consonant, second letter vowel or "y" (uppercase first)
-      if (!in_array(strtolower($word{0}), $this->dict['vowels']) && (in_array(strtolower($word{1}), $this->dict['vowels']) || strtolower($word{1}) == 'y')) {
-        $word = ucfirst(strtolower($word));
+      if (!in_array(mb_strtolower($word{0}), $this->dict['vowels']) && (in_array(mb_strtolower($word{1}), $this->dict['vowels']) || mb_strtolower($word{1}) == 'y')) {
+        $word = ucfirst(mb_strtolower($word));
       }
     }
 
     # Fix case for words which aren't initials, but are all uppercase or lowercase
-    if ( (strlen($word) >= 3) && (ctype_upper($word) || ctype_lower($word)) ) {
-      $word = ucfirst(strtolower($word));
+    if ( (mb_strlen($word) >= 3) && ($this->mb_ctype_upper($word) || $this->mb_ctype_lower($word)) ) {
+      $word = ucfirst(mb_strtolower($word));
     }
 
     return $word;
@@ -515,9 +515,36 @@ class FullNameParser {
     # uppercase words split by the seperator (ex. dashes or periods)
     $parts = explode($seperator, $word);
     foreach ($parts as $word) {
-      $words[] = ($this->is_camel_case($word)) ? $word : ucfirst(strtolower($word));
+      $words[] = ($this->is_camel_case($word)) ? $word : ucfirst(mb_strtolower($word));
     }
     return implode($seperator, $words);
   }
 
+    # helper public function for multibytes ctype_alpha
+    public function mb_ctype_alpha($text)
+    {
+        return (bool)preg_match('/^\p{L}*$/', $text);
+    }
+
+    # helper public function for multibytes ctype_lower
+    public function mb_ctype_lower($text)
+    {
+        return (bool)preg_match('/^\p{Ll}*$/', $text);
+    }
+
+    # helper public function for multibytes ctype_upper
+    public function mb_ctype_upper($text)
+    {
+        return (bool)preg_match('/^\p{Lu}*$/', $text);
+    }
+
+    # helper public function for multibytes str_word_count
+    public function mb_str_word_count($text)
+    {
+        if (empty($text)) {
+            return 0;
+        } else {
+            return preg_match('/s+/', $text) + 1;
+        }
+    }
 }

--- a/parser.php
+++ b/parser.php
@@ -494,17 +494,17 @@ class FullNameParser {
       }
       # First letter is vowel, second letter consonant (uppercase first)
       if (in_array(mb_strtolower($word{0}), $this->dict['vowels']) && !in_array(mb_strtolower($word{1}), $this->dict['vowels'])) {
-        $word = ucfirst(mb_strtolower($word));
+        $word = $this->mb_ucfirst(mb_strtolower($word));
       }
       # First letter consonant, second letter vowel or "y" (uppercase first)
       if (!in_array(mb_strtolower($word{0}), $this->dict['vowels']) && (in_array(mb_strtolower($word{1}), $this->dict['vowels']) || mb_strtolower($word{1}) == 'y')) {
-        $word = ucfirst(mb_strtolower($word));
+        $word = $this->mb_ucfirst(mb_strtolower($word));
       }
     }
 
     # Fix case for words which aren't initials, but are all uppercase or lowercase
     if ( (mb_strlen($word) >= 3) && ($this->mb_ctype_upper($word) || $this->mb_ctype_lower($word)) ) {
-      $word = ucfirst(mb_strtolower($word));
+      $word = $this->mb_ucfirst(mb_strtolower($word));
     }
 
     return $word;
@@ -515,7 +515,7 @@ class FullNameParser {
     # uppercase words split by the seperator (ex. dashes or periods)
     $parts = explode($seperator, $word);
     foreach ($parts as $word) {
-      $words[] = ($this->is_camel_case($word)) ? $word : ucfirst(mb_strtolower($word));
+      $words[] = ($this->is_camel_case($word)) ? $word : $this->mb_ucfirst(mb_strtolower($word));
     }
     return implode($seperator, $words);
   }
@@ -523,28 +523,37 @@ class FullNameParser {
     # helper public function for multibytes ctype_alpha
     public function mb_ctype_alpha($text)
     {
-        return (bool)preg_match('/^\p{L}*$/', $text);
+      return (bool)preg_match('/^\p{L}*$/', $text);
     }
 
     # helper public function for multibytes ctype_lower
     public function mb_ctype_lower($text)
     {
-        return (bool)preg_match('/^\p{Ll}*$/', $text);
+      return (bool)preg_match('/^\p{Ll}*$/', $text);
     }
 
     # helper public function for multibytes ctype_upper
     public function mb_ctype_upper($text)
     {
-        return (bool)preg_match('/^\p{Lu}*$/', $text);
+      return (bool)preg_match('/^\p{Lu}*$/', $text);
     }
 
     # helper public function for multibytes str_word_count
     public function mb_str_word_count($text)
     {
-        if (empty($text)) {
-            return 0;
-        } else {
-            return preg_match('/s+/', $text) + 1;
-        }
+      if (empty($text)) {
+        return 0;
+      } else {
+        return preg_match('/s+/', $text) + 1;
+      }
+    }
+
+    # helper public function for multibytes ucfirst
+    public function mb_ucfirst($string)
+    {
+      $strlen = mb_strlen($string);
+      $firstChar = mb_substr($string, 0, 1);
+      $then = mb_substr($string, 1, $strlen - 1);
+      return mb_strtoupper($firstChar) . $then;
     }
 }


### PR DESCRIPTION
# Multibytes string

Edits that allow to use the fullname parser with mulltibytes string (mainly for unicode characters).

## ctype functions

`ctype` functions has been replaced with them `preg_match` equivalent using unicode regex properties (see http://php.net/manual/en/regexp.reference.unicode.php) :

* `ctype_alpha` has been replaced by a new method `mb_ctype_alpha` (`preg_match('/^\p{L}*$/', $str)`) ;
* `ctype_lower` has been replaced by a new method `mb_ctype_lower` (`preg_match('/^\p{Ll}*$/', $str)`) ;
* `ctype_upper` has been replaced by a new method `mb_ctype_upper` (`preg_match('/^\p{Lu}*$/', $str)`).

## string functions

String functions has been replaced with their multibytes equivalent :

* `strlen` is now `mb_strlen` ;
* `strpos` is now `mb_strpos` ;
* `strtolower` is now `mb_strtolower` ;
* `strtoupper` is now `mb_strtoupper` ;
* `substr` is now `mb_substr`.

## str_word_count

I didn't found a way to make a perfect unicode `str_word_count`, so I used `preg_match` to find the number of blank spaces in the string to deduce the number of words. `str_word_count` calls has been replaced by a new method `mb_str_word_count`.

For my tests it works, but this may not be the best solution.

## CamelCase regex

The camel regex has been replaced with the unicode equivalent : `\p{L}(\p{Lu}*\p{Ll}\p{Ll}*\p{Lu}|\p{Ll}*\p{Lu}\p{Lu}*\p{Ll})\p{L}*`.

## ucfirst

`ucfirst` has been replaced by a a new method `mb_ucfirst`.