### PR TITLE
Fix PHP deprecation errors. Clean up examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "joshfraser/php-name-parser",
     "description": "PHP library to split names into their respective components (first, last, etc)",
     "require": {
-        "php": "^5.3.3 || ^7.0"
+        "php": "^5.5 || ^7.0"
     },
     "autoload": {
         "files": [

--- a/examples.php
+++ b/examples.php
@@ -5,279 +5,386 @@ require_once('parser.php');
 // examples & a poor mans test suite
 // intentionally shows examples that fail
 
-$names = array(
-  "Mr Anthony R Von Fange III"      => array("salutation" => "Mr.",
-                                            "fname" => "Anthony",
-                                            "initials" => "R",
-                                            "lname" => "Von Fange",
-                                            "suffix" => "III"),
-  "J. B. Hunt"                      => array("salutation" => "",
-                                              "fname" => "J.",
-                                              "initials" => "B.",
-                                              "lname" => "Hunt",
-                                              "suffix" => ""),
-  "J.B. Hunt"                       => array("salutation" => "",
-                                              "fname" => "J.B.",
-                                              "initials" => "",
-                                              "lname" => "Hunt",
-                                              "suffix" => ""),
-  "Edward Senior III"               => array("salutation" => "",
-                                              "fname" => "Edward",
-                                              "initials" => "",
-                                              "lname" => "Senior",
-                                              "suffix" => "III"),
-  "Edward Dale Senior II"           => array("salutation" => "",
-                                              "fname" => "Edward Dale",
-                                              "initials" => "",
-                                              "lname" => "Senior",
-                                              "suffix" => "II"),
-  "Dale Edward Jones Senior"        => array("salutation" => "",
-                                              "fname" => "Dale Edward",
-                                              "initials" => "",
-                                              "lname" => "Jones",
-                                              "suffix" => "Senior"),
-  "Edward Senior II"                => array("salutation" => "",
-                                              "fname" => "Edward",
-                                              "initials" => "",
-                                              "lname" => "Senior",
-                                              "suffix" => "II"),
-  "Dale Edward Senior II, PhD"      => array("salutation" => "",
-                                              "fname" => "Dale Edward",
-                                              "initials" => "",
-                                              "lname" => "Senior",
-                                              "suffix" => "II, PhD"),
-  "Jason Rodriguez Sr."             =>  array("salutation" => "",
-                                              "fname" => "Jason",
-                                              "initials" => "",
-                                              "lname" => "Rodriguez",
-                                              "suffix" => "Sr"),
-  "Jason Senior"                    =>  array("salutation" => "",
-                                              "fname" => "Jason",
-                                              "initials" => "",
-                                              "lname" => "Senior",
-                                              "suffix" => ""),
-  "Bill Junior"                     =>  array("salutation" => "",
-                                              "fname" => "Bill",
-                                              "initials" => "",
-                                              "lname" => "Junior",
-                                              "suffix" => ""),
-  "Sara Ann Fraser"                 =>  array("salutation" => "",
-                                              "fname" => "Sara Ann",
-                                              "initials" => "",
-                                              "lname" => "Fraser",
-                                              "suffix" => ""),
-  "Adam"                            =>  array("salutation" => "",
-                                              "fname" => "Adam",
-                                              "initials" => "",
-                                              "lname" => "",
-                                              "suffix" => ""),
-  "OLD MACDONALD"                   =>  array("salutation" => "",
-                                              "fname" => "Old",
-                                              "initials" => "",
-                                              "lname" => "Macdonald",
-                                              "suffix" => ""),
-  "Old MacDonald"                   =>  array("salutation" => "",
-                                              "fname" => "Old",
-                                              "initials" => "",
-                                              "lname" => "MacDonald",
-                                              "suffix" => ""),
-  "Old McDonald"                    =>  array("salutation" => "",
-                                              "fname" => "Old",
-                                              "initials" => "",
-                                              "lname" => "McDonald",
-                                              "suffix" => ""),
-  "Old Mc Donald"                   =>  array("salutation" => "",
-                                              "fname" => "Old Mc",
-                                              "initials" => "",
-                                              "lname" => "Donald",
-                                              "suffix" => ""),
-  "Old Mac Donald"                  =>  array("salutation" => "",
-                                              "fname" => "Old Mac",
-                                              "initials" => "",
-                                              "lname" => "Donald",
-                                              "suffix" => ""),
-  "James van Allen"                 =>  array("salutation" => "",
-                                              "fname" => "James",
-                                              "initials" => "",
-                                              "lname" => "Van Allen",
-                                              "suffix" => ""),
-  "Jimmy (Bubba) Smith"             =>  array("nickname" => "Bubba",
-                                              "salutation" => "",
-                                              "fname" => "Jimmy",
-                                              "initials" => "",
-                                              "lname" => "Smith",
-                                              "suffix" => ""),
-  "Miss Jennifer Shrader Lawrence"  =>  array("salutation" => "Ms.",
-                                              "fname" => "Jennifer Shrader",
-                                              "initials" => "",
-                                              "lname" => "Lawrence",
-                                              "suffix" => ""),
-  "Jonathan Smith, MD"              =>  array("salutation" => "",
-                                              "fname" => "Jonathan",
-                                              "initials" => "",
-                                              "lname" => "Smith",
-                                              "suffix" => "MD"),
-  "Dr. Jonathan Smith"              =>  array("salutation" => "Dr.",
-                                              "fname" => "Jonathan",
-                                              "initials" => "",
-                                              "lname" => "Smith",
-                                              "suffix" => ""),
-  "Jonathan Smith IV, PhD"          =>  array("salutation" => "",
-                                              "fname" => "Jonathan",
-                                              "initials" => "",
-                                              "lname" => "Smith",
-                                              "suffix" => "IV, PhD"),
-  "Miss Jamie P. Harrowitz"         =>  array("salutation" => "Ms.",
-                                              "fname" => "Jamie",
-                                              "initials" => "P.",
-                                              "lname" => "Harrowitz",
-                                              "suffix" => ""),
-  "Mr John Doe"                     =>  array("salutation" => "Mr.",
-                                              "fname" => "John",
-                                              "initials" => "",
-                                              "lname" => "Doe",
-                                              "suffix" => ""),
-  "Rev. Dr John Doe"                =>  array("salutation" => "Rev. Dr.",
-                                              "fname" => "John",
-                                              "initials" => "",
-                                              "lname" => "Doe",
-                                              "suffix" => ""),
-  "Anthony Von Fange III"           =>  array("salutation" => "",
-                                              "fname" => "Anthony",
-                                              "initials" => "",
-                                              "lname" => "Von Fange",
-                                              "suffix" => "III"),
-  "Anthony Von Fange III, PhD"      =>  array("salutation" => "",
-                                              "fname" => "Anthony",
-                                              "initials" => "",
-                                              "lname" => "Von Fange",
-                                              "suffix" => "III, PhD"),
-  "Smarty Pants Phd"                =>  array("salutation" => "",
-                                              "fname" => "Smarty",
-                                              "initials" => "",
-                                              "lname" => "Pants",
-                                              "suffix" => "PhD"),
-  "Mark Peter Williams"             =>  array("salutation" => "",
-                                              "fname" => "Mark Peter",
-                                              "initials" => "",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  "Mark P Williams"                 =>  array("salutation" => "",
-                                              "fname" => "Mark",
-                                              "initials" => "P",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  "Mark P. Williams"                =>  array("salutation" => "",
-                                              "fname" => "Mark",
-                                              "initials" => "P.",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  "M Peter Williams"                =>  array("salutation" => "",
-                                              "fname" => "Peter",
-                                              "initials" => "M",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  "M. Peter Williams"               =>  array("salutation" => "",
-                                              "fname" => "Peter",
-                                              "initials" => "M.",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  "M. P. Williams"                  =>  array("salutation" => "",
-                                              "fname" => "M.",
-                                              "initials" => "P.",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  "The Rev. Mark Williams"          =>  array("salutation" => "Rev.",
-                                              "fname" => "Mark",
-                                              "initials" => "",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  "Mister Mark Williams"          =>  array("salutation" => "Mr.",
-                                              "fname" => "Mark",
-                                              "initials" => "",
-                                              "lname" => "Williams",
-                                              "suffix" => ""),
-  // fails. format not yet supported
-  "Fraser, Joshua"                  =>  array("salutation" => "",
-                                              "fname" => "Joshua",
-                                              "initials" => "",
-                                              "lname" => "Fraser",
-                                              "suffix" => ""),
-  // fails. both initials should be capitalized
-  "JB Hunt"                         => array("salutation" => "",
-                                              "fname" => "JB",
-                                              "initials" => "",
-                                              "lname" => "Hunt",
-                                              "suffix" => ""),
-  // fails.  doesn't handle multiple words inside parenthesis
-  "Jimmy (Bubba Junior) Smith"      =>  array("nickname" => "Bubba Junior",
-                                              "salutation" => "",
-                                              "fname" => "Jimmy",
-                                              "initials" => "",
-                                              "lname" => "Smith",
-                                              "suffix" => ""),
-  // fails.  should normalize the PhD suffix
-  "Anthony Von Fange III, PHD"      =>  array("salutation" => "",
-                                              "fname" => "Anthony",
-                                              "initials" => "",
-                                              "lname" => "Von Fange",
-                                              "suffix" => "III, PhD"),
-  // fails.  should treat "Silly" as the nickname or remove altogether
-  "Not So Smarty Pants, Silly"      =>  array("nickname" => "Silly",
-                                              "salutation" => "",
-                                              "fname" => "Not So Smarty",
-                                              "initials" => "",
-                                              "lname" => "Pants",
-                                              "suffix" => ""),
-  "Rev Al Sharpton"                 =>  array("salutation" => "Rev.",
-                                              "fname" => "Al",
-                                              "initials" => "",
-                                              "lname" => "Sharpton",
-                                              "suffix" => ""),
-  "Dr Ty P. Bennington iIi"                 =>  array("salutation" => "Dr.",
-                                              "fname" => "Ty",
-                                              "initials" => "P.",
-                                              "lname" => "Bennington",
-                                              "suffix" => "III"),
-);
-
+$names = [
+    "Mr Anthony R Von Fange III"     => [
+        "salutation" => "Mr.",
+        "fname"      => "Anthony",
+        "initials"   => "R",
+        "lname"      => "Von Fange",
+        "suffix"     => "III",
+    ],
+    "J. B. Hunt"                     => [
+        "salutation" => "",
+        "fname"      => "J.",
+        "initials"   => "B.",
+        "lname"      => "Hunt",
+        "suffix"     => "",
+    ],
+    "J.B. Hunt"                      => [
+        "salutation" => "",
+        "fname"      => "J.B.",
+        "initials"   => "",
+        "lname"      => "Hunt",
+        "suffix"     => "",
+    ],
+    "Edward Senior III"              => [
+        "salutation" => "",
+        "fname"      => "Edward",
+        "initials"   => "",
+        "lname"      => "Senior",
+        "suffix"     => "III",
+    ],
+    "Edward Dale Senior II"          => [
+        "salutation" => "",
+        "fname"      => "Edward Dale",
+        "initials"   => "",
+        "lname"      => "Senior",
+        "suffix"     => "II",
+    ],
+    "Dale Edward Jones Senior"       => [
+        "salutation" => "",
+        "fname"      => "Dale Edward",
+        "initials"   => "",
+        "lname"      => "Jones",
+        "suffix"     => "Senior",
+    ],
+    "Edward Senior II"               => [
+        "salutation" => "",
+        "fname"      => "Edward",
+        "initials"   => "",
+        "lname"      => "Senior",
+        "suffix"     => "II",
+    ],
+    "Dale Edward Senior II, PhD"     => [
+        "salutation" => "",
+        "fname"      => "Dale Edward",
+        "initials"   => "",
+        "lname"      => "Senior",
+        "suffix"     => "II, PhD",
+    ],
+    "Jason Rodriguez Sr."            => [
+        "salutation" => "",
+        "fname"      => "Jason",
+        "initials"   => "",
+        "lname"      => "Rodriguez",
+        "suffix"     => "Sr",
+    ],
+    "Jason Senior"                   => [
+        "salutation" => "",
+        "fname"      => "Jason",
+        "initials"   => "",
+        "lname"      => "Senior",
+        "suffix"     => "",
+    ],
+    "Bill Junior"                    => [
+        "salutation" => "",
+        "fname"      => "Bill",
+        "initials"   => "",
+        "lname"      => "Junior",
+        "suffix"     => "",
+    ],
+    "Sara Ann Fraser"                => [
+        "salutation" => "",
+        "fname"      => "Sara Ann",
+        "initials"   => "",
+        "lname"      => "Fraser",
+        "suffix"     => "",
+    ],
+    "Adam"                           => [
+        "salutation" => "",
+        "fname"      => "Adam",
+        "initials"   => "",
+        "lname"      => "",
+        "suffix"     => "",
+    ],
+    "OLD MACDONALD"                  => [
+        "salutation" => "",
+        "fname"      => "Old",
+        "initials"   => "",
+        "lname"      => "Macdonald",
+        "suffix"     => "",
+    ],
+    "Old MacDonald"                  => [
+        "salutation" => "",
+        "fname"      => "Old",
+        "initials"   => "",
+        "lname"      => "MacDonald",
+        "suffix"     => "",
+    ],
+    "Old McDonald"                   => [
+        "salutation" => "",
+        "fname"      => "Old",
+        "initials"   => "",
+        "lname"      => "McDonald",
+        "suffix"     => "",
+    ],
+    "Old Mc Donald"                  => [
+        "salutation" => "",
+        "fname"      => "Old Mc",
+        "initials"   => "",
+        "lname"      => "Donald",
+        "suffix"     => "",
+    ],
+    "Old Mac Donald"                 => [
+        "salutation" => "",
+        "fname"      => "Old Mac",
+        "initials"   => "",
+        "lname"      => "Donald",
+        "suffix"     => "",
+    ],
+    "James van Allen"                => [
+        "salutation" => "",
+        "fname"      => "James",
+        "initials"   => "",
+        "lname"      => "Van Allen",
+        "suffix"     => "",
+    ],
+    "Jimmy (Bubba) Smith"            => [
+        "nickname"   => "Bubba",
+        "salutation" => "",
+        "fname"      => "Jimmy",
+        "initials"   => "",
+        "lname"      => "Smith",
+        "suffix"     => "",
+    ],
+    "Miss Jennifer Shrader Lawrence" => [
+        "salutation" => "Ms.",
+        "fname"      => "Jennifer Shrader",
+        "initials"   => "",
+        "lname"      => "Lawrence",
+        "suffix"     => "",
+    ],
+    "Jonathan Smith, MD"             => [
+        "salutation" => "",
+        "fname"      => "Jonathan",
+        "initials"   => "",
+        "lname"      => "Smith",
+        "suffix"     => "MD",
+    ],
+    "Dr. Jonathan Smith"             => [
+        "salutation" => "Dr.",
+        "fname"      => "Jonathan",
+        "initials"   => "",
+        "lname"      => "Smith",
+        "suffix"     => "",
+    ],
+    "Jonathan Smith IV, PhD"         => [
+        "salutation" => "",
+        "fname"      => "Jonathan",
+        "initials"   => "",
+        "lname"      => "Smith",
+        "suffix"     => "IV, PhD",
+    ],
+    "Miss Jamie P. Harrowitz"        => [
+        "salutation" => "Ms.",
+        "fname"      => "Jamie",
+        "initials"   => "P.",
+        "lname"      => "Harrowitz",
+        "suffix"     => "",
+    ],
+    "Mr John Doe"                    => [
+        "salutation" => "Mr.",
+        "fname"      => "John",
+        "initials"   => "",
+        "lname"      => "Doe",
+        "suffix"     => "",
+    ],
+    "Rev. Dr John Doe"               => [
+        "salutation" => "Rev. Dr.",
+        "fname"      => "John",
+        "initials"   => "",
+        "lname"      => "Doe",
+        "suffix"     => "",
+    ],
+    "Anthony Von Fange III"          => [
+        "salutation" => "",
+        "fname"      => "Anthony",
+        "initials"   => "",
+        "lname"      => "Von Fange",
+        "suffix"     => "III",
+    ],
+    "Anthony Von Fange III, PhD"     => [
+        "salutation" => "",
+        "fname"      => "Anthony",
+        "initials"   => "",
+        "lname"      => "Von Fange",
+        "suffix"     => "III, PhD",
+    ],
+    "Smarty Pants Phd"               => [
+        "salutation" => "",
+        "fname"      => "Smarty",
+        "initials"   => "",
+        "lname"      => "Pants",
+        "suffix"     => "PhD",
+    ],
+    "Mark Peter Williams"            => [
+        "salutation" => "",
+        "fname"      => "Mark Peter",
+        "initials"   => "",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    "Mark P Williams"                => [
+        "salutation" => "",
+        "fname"      => "Mark",
+        "initials"   => "P",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    "Mark P. Williams"               => [
+        "salutation" => "",
+        "fname"      => "Mark",
+        "initials"   => "P.",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    "M Peter Williams"               => [
+        "salutation" => "",
+        "fname"      => "Peter",
+        "initials"   => "M",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    "M. Peter Williams"              => [
+        "salutation" => "",
+        "fname"      => "Peter",
+        "initials"   => "M.",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    "M. P. Williams"                 => [
+        "salutation" => "",
+        "fname"      => "M.",
+        "initials"   => "P.",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    "The Rev. Mark Williams"         => [
+        "salutation" => "Rev.",
+        "fname"      => "Mark",
+        "initials"   => "",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    "Mister Mark Williams"           => [
+        "salutation" => "Mr.",
+        "fname"      => "Mark",
+        "initials"   => "",
+        "lname"      => "Williams",
+        "suffix"     => "",
+    ],
+    // fails. format not yet supported
+    "Fraser, Joshua"                 => [
+        "salutation" => "",
+        "fname"      => "Joshua",
+        "initials"   => "",
+        "lname"      => "Fraser",
+        "suffix"     => "",
+    ],
+    // fails. both initials should be capitalized
+    "JB Hunt"                        => [
+        "salutation" => "",
+        "fname"      => "JB",
+        "initials"   => "",
+        "lname"      => "Hunt",
+        "suffix"     => "",
+    ],
+    // fails.  doesn't handle multiple words inside parenthesis
+    "Jimmy (Bubba Junior) Smith"     => [
+        "nickname"   => "Bubba Junior",
+        "salutation" => "",
+        "fname"      => "Jimmy",
+        "initials"   => "",
+        "lname"      => "Smith",
+        "suffix"     => "",
+    ],
+    // fails.  should normalize the PhD suffix
+    "Anthony Von Fange III, PHD"     => [
+        "salutation" => "",
+        "fname"      => "Anthony",
+        "initials"   => "",
+        "lname"      => "Von Fange",
+        "suffix"     => "III, PhD",
+    ],
+    // fails.  should treat "Silly" as the nickname or remove altogether
+    "Not So Smarty Pants, Silly"     => [
+        "nickname"   => "Silly",
+        "salutation" => "",
+        "fname"      => "Not So Smarty",
+        "initials"   => "",
+        "lname"      => "Pants",
+        "suffix"     => "",
+    ],
+    "Rev Al Sharpton"                => [
+        "salutation" => "Rev.",
+        "fname"      => "Al",
+        "initials"   => "",
+        "lname"      => "Sharpton",
+        "suffix"     => "",
+    ],
+    "Dr Ty P. Bennington iIi"        => [
+        "salutation" => "Dr.",
+        "fname"      => "Ty",
+        "initials"   => "P.",
+        "lname"      => "Bennington",
+        "suffix"     => "III",
+    ],
+];
 
 $parser = new FullNameParser();
 
-$headers = array("salutation","fname","initials","lname","suffix","nickname");
+$headers = ["salutation", "fname", "initials", "lname", "suffix", "nickname"];
+
 ?>
 <!DOCTYPE html>
 <html lang="en-US">
-  <head>
+<head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>PHP Name Parser | Unit Tests</title>
     <link rel="stylesheet" href="./tests/style.css" type="text/css" media="all">
-  </head>
-  <body>
-    <div class="wrapper">
-      <table class="unit-tests">
+</head>
+<body>
+<div class="wrapper">
+    <table class="unit-tests">
         <thead>
-          <tr>
+        <tr>
             <th>Full Name</th>
-<?php foreach ($headers as $col): ?>
-            <th><?= ucfirst($col); ?></th>
-<?php endforeach; ?>
+            <?php foreach ($headers as $col): ?>
+                <th><?= ucfirst($col); ?></th>
+            <?php endforeach; ?>
+            <th>Expected</th>
+            <th>Parsed</th>
             <th>Passed</th>
-          </tr>
+        </tr>
         </thead>
         <tbody>
-<?php foreach ($names as $name => $expected_values): $split_name = $parser->parse_name($name); $passed = ($split_name === $expected_values); ?>
-          <tr class="<?= ($passed) ? 'pass' : 'fail'; ?>">
-            <td><?= $name; ?></td>
-<?php foreach ($headers as $col): ?>
-            <td><?= (isset($split_name[$col])) ? $split_name[$col] : ''; ?></td>
-<?php endforeach; ?>
-            <td><?= ($passed) ? 'PASS' : 'FAIL'; ?></td>
-          </tr>
-<?php endforeach; ?>
+        <?php
+
+        foreach ($names as $name => $expected_values):
+            $split_name = $parser->parse_name($name);
+            $passed = empty(array_diff_assoc($expected_values, $split_name));
+
+            ?>
+            <tr class="<?= ($passed) ? 'pass' : 'fail'; ?>">
+                <td><?= $name; ?></td>
+                <?php foreach ($headers as $col): ?>
+                    <td><?= (isset($split_name[$col])) ? $split_name[$col] : ''; ?></td>
+                <?php endforeach; ?>
+                <td class="raw">
+                    <pre><?= json_encode($expected_values, JSON_PRETTY_PRINT); ?></pre>
+                </td>
+                <td class="raw">
+                    <pre><?= json_encode($split_name, JSON_PRETTY_PRINT); ?></pre>
+                </td>
+                <td><?= ($passed) ? 'PASS' : 'FAIL'; ?></td>
+            </tr>
+        <?php
+        endforeach;
+
+        ?>
         </tbody>
-      </table>
-    </div>
-  </body>
+    </table>
+</div>
+</body>
 </html>

--- a/parser.php
+++ b/parser.php
@@ -454,7 +454,7 @@ class FullNameParser {
    * @return boolean
    */
   protected function is_initial($word) {
-    return ((mb_strlen($word) == 1) || (mb_strlen($word) == 2 && $word{1} == "."));
+    return ((mb_strlen($word) == 1) || (mb_strlen($word) == 2 && $word[1] == "."));
   }
 
 
@@ -494,19 +494,19 @@ class FullNameParser {
     # Special case for 2-letter words
     if (mb_strlen($word) == 2) {
       # Both letters vowels (uppercase both)
-      if (in_array(mb_strtolower($word{0}), $this->dict['vowels']) && in_array(mb_strtolower($word{1}), $this->dict['vowels'])) {
+      if (in_array(mb_strtolower($word[0]), $this->dict['vowels']) && in_array(mb_strtolower($word[1]), $this->dict['vowels'])) {
         $word = mb_strtoupper($word);
       }
       # Both letters consonants (uppercase both)
-      if (!in_array(mb_strtolower($word{0}), $this->dict['vowels']) && !in_array(mb_strtolower($word{1}), $this->dict['vowels'])) {
+      if (!in_array(mb_strtolower($word[0]), $this->dict['vowels']) && !in_array(mb_strtolower($word[1]), $this->dict['vowels'])) {
         $word = mb_strtoupper($word);
       }
       # First letter is vowel, second letter consonant (uppercase first)
-      if (in_array(mb_strtolower($word{0}), $this->dict['vowels']) && !in_array(mb_strtolower($word{1}), $this->dict['vowels'])) {
+      if (in_array(mb_strtolower($word[0]), $this->dict['vowels']) && !in_array(mb_strtolower($word[1]), $this->dict['vowels'])) {
         $word = $this->mb_ucfirst(mb_strtolower($word));
       }
       # First letter consonant, second letter vowel or "y" (uppercase first)
-      if (!in_array(mb_strtolower($word{0}), $this->dict['vowels']) && (in_array(mb_strtolower($word{1}), $this->dict['vowels']) || mb_strtolower($word{1}) == 'y')) {
+      if (!in_array(mb_strtolower($word[0]), $this->dict['vowels']) && (in_array(mb_strtolower($word[1]), $this->dict['vowels']) || mb_strtolower($word[1]) == 'y')) {
         $word = $this->mb_ucfirst(mb_strtolower($word));
       }
     }

--- a/tests/style.css
+++ b/tests/style.css
@@ -1,11 +1,11 @@
 table { border-collapse: collapse; border-spacing: 0; font-family: 'Open Sans', sans-serif; font-weight: 300 }
 thead { display: table-header-group }
 tr{ page-break-inside: avoid; }
-.wrapper { width:75%; margin:30px auto; overflow: hidden; }
+.wrapper { width:95%; margin:30px auto; overflow: hidden; }
 .unit-tests { float: left; width: 100%; border-bottom: 1px solid #ddd; }
 .unit-tests thead{ background:#666; border: 1px solid #555; }
-.unit-tests tr th{ padding: 0px 24px; height: 48px; line-height: 48px; font-weight: 900; color:#fff; border-right:1px solid #555  }
-.unit-tests tbody td { padding: 0px 24px; height: 48px; line-height: 48px; text-align: center; border:1px solid #ddd; }
+.unit-tests tr th{ padding: 0px 10px; line-height: 24px; font-weight: 900; color:#fff; border-right:1px solid #555  }
+.unit-tests tbody td { padding: 0px 10px; line-height: 24px; text-align: center; border:1px solid #ddd; }
 .unit-tests tbody tr:first-child td { border-top:0 none; }
 .unit-tests tr td:first-child,
 .unit-tests tr th:first-child{ text-align: left; }
@@ -13,6 +13,7 @@ tr{ page-break-inside: avoid; }
 .unit-tests tbody tr:nth-child(even) { background:#f8f8f8; }
 .unit-tests tbody tr:hover { cursor:default; border-color:rgba(0,0,0,0.04); }
 .unit-tests tbody tr:hover td { border-color:rgba(0,0,0,0.06); }
+.unit-tests tbody td.raw { text-align: left; line-height: 12px;  }
 .unit-tests tbody .pass td:last-child { background:#ecffc1; border-color:rgba(0,0,0,0.04); border-right-color:rgba(0,0,0,0.1); color:#7ec43c; }
 .unit-tests tbody .fail td:last-child { background:#ffc1c1; border-color:rgba(0,0,0,0.03); border-right-color:rgba(0,0,0,0.1); color:#e53d3d; }
 .unit-tests tbody .pass:hover { background:#ecffc1; color:#7ec43c; }


### PR DESCRIPTION
I was getting these warnings over and over again in any project that I used this parser in:

```
Deprecated: Array and string offset access syntax with curly braces is deprecated in /vendor/joshfraser/php-name-parser/parser.php on line 457
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /vendor/joshfraser/php-name-parser/parser.php on line 497
```

It was driving me nuts, so I fixed it ;)

I also cleaned up the examples page a bit and added the expected and parsed arrays as JSON:

![image](https://user-images.githubusercontent.com/748444/83200246-26212600-a100-11ea-8134-4cdb516c6d9e.png)
